### PR TITLE
WIP: support JDK 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .*
 *~
 *.iml
+tags
+tmp/

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.21.0</version>
                 <configuration>
                     <excludes>
                         <exclude>org.cyclopsgroup.jmxterm.jdk*</exclude>

--- a/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
@@ -1,5 +1,6 @@
 package org.cyclopsgroup.jmxterm.pm;
 
+import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 
 import java.io.File;
@@ -21,6 +22,9 @@ public class JConsoleClassLoaderFactory {
    * @return ClassLoader that understands tools.jar and jconsole.jar
    */
   public static ClassLoader getClassLoader() {
+    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      return ClassLoader.getSystemClassLoader();
+    }
     File javaHome = new File(SystemUtils.JAVA_HOME).getAbsoluteFile().getParentFile();
     final File toolsJar, jconsoleJar;
     if (isBeforeJava7() && isMacOs()) {


### PR DESCRIPTION
compiled jar: https://github.com/koron/jmxterm/releases/tag/jdk10a

how to compile: `mvn -e clean package`
how to run: `java -jar jmxterm-1.0.1-SNAPSHOT-uber.jar`

---

Some warnings are occurred on on JDK 9 and 10

```
$>jvms
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.cyclopsgroup.jmxterm.utils.WeakCastUtils$2 (file:/home/koron/work/github.com/jiaqi/jmxterm/target/jmxterm-1.0.1-SNAPSHOT-uber.jar) to method sun.tools.jconsole.LocalVirtualMachine.getAllVirtualMachines()
WARNING: Please consider reporting this to the maintainers of org.cyclopsgroup.jmxterm.utils.WeakCastUtils$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```